### PR TITLE
Replace `headerFields` getter with `map` instead of `flatMap`;

### DIFF
--- a/SwiftyRequest/Request.swift
+++ b/SwiftyRequest/Request.swift
@@ -28,7 +28,7 @@ public extension Request {
   
   var headerFields: [Header: String]? {
     get {
-      return allHTTPHeaderFields.flatMap { dictionary in
+      return allHTTPHeaderFields.map { dictionary in
         Dictionary(uniqueKeysWithValues: dictionary.compactMap { key, value in
           guard let key = Header(rawValue: key) else { return nil }
           return (key, value)


### PR DESCRIPTION
The closure provided to `allHTTPHeaderFields.flatMap(_:)` did not create
an optional, so the call to `flatMap` to prevent a nested optional was unneccesary